### PR TITLE
Fix suggested normal mode mapping to use nnoremap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ and then you can just issue `:CommaOrSemiColon`.
 
 ### Using it via mappings
 
-Example mapping the key combo `<Leader>;` for both `normal` and `insert` modes:
+An example mapping, using the key combo `<Leader>;` for both `normal` and `insert` modes:
 
 ```VimL
-autocmd FileType javascript,css,YOUR_LANG noremap <silent> <Leader>; :call cosco#commaOrSemiColon()<CR>
+autocmd FileType javascript,css,YOUR_LANG nnoremap <silent> <Leader>; :call cosco#commaOrSemiColon()<CR>
 autocmd FileType javascript,css,YOUR_LANG inoremap <silent> <Leader>; <c-o>:call cosco#commaOrSemiColon()<CR>
 ```
 


### PR DESCRIPTION
[`noremap`](http://vimdoc.sourceforge.net/htmldoc/map.html#:noremap) maps Normal, Visual, Select, and Operator modes. You want [`nnoremap`](http://vimdoc.sourceforge.net/htmldoc/map.html#:nnoremap), which maps only Normal mode.

I also fixed the grammar of the sentence above the code.