### PR TITLE
Support TeX/LaTeX.

### DIFF
--- a/autoload/filetypes/tex.vim
+++ b/autoload/filetypes/tex.vim
@@ -1,0 +1,13 @@
+function! filetypes#tex#parse()
+    let b:wasExtensionExecuted = 1
+
+    if b:currentLineFirstChar == '%'
+        " do nothing: it's a comment
+    elseif b:currentLineLastChar == '%'
+        " toggle percent sign
+        exec("s/%$//")
+    else
+        " append percent sign
+        exec("s/$/%/")
+    endif
+endfunction


### PR DESCRIPTION
In TeX semicolons are not used to terminate statements.
Also lists are uncommon so there is no need for the comma either.
But there is a another use case for this plugin.
It is a frequently task to append a '%' at the end of a line to avoid an
additional space being added by TeX.

Example:

```TeX
no-sp%
ace
```

which is typeset as "no-space". Without the '%' it would be 'no-sp ace'.