### PR TITLE
Add the choice for inserting comma or semicolon automatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,7 @@ Cosco command won't override any mappings or commands you might already have. Yo
 Here you can find two examples on how to do this. Put them on your `.vimrc`.
 
 ### Using it via command
-
-```VimL
-command! CommaOrSemiColon call cosco#commaOrSemiColon()
-```
-
-and then you can just issue `:CommaOrSemiColon`.
+Go to the target line then: `:CommaOrSemiColon`
 
 ### Using it via mappings
 
@@ -55,6 +50,36 @@ autocmd FileType javascript,css,YOUR_LANG inoremap <silent> <Leader>; <c-o>:call
 ```
 
 and then you can just type `<Leader>;`.
+
+## Auto CommaOrSemicolon Insertion Mode
+
+Auto insertion of a comma or a semicolon is also supported through the function:
+
+```vim
+:call AutoCommaOrSemiColon()
+```
+To activate the AutoCommaOrSemiColon by default add the following line to your `.vimrc`:
+
+```vim
+let g:auto_comma_or_semicolon = 1     " Default : 0
+```
+
+For faster toggle you can use the command:
+
+```vim
+:AutoCommaOrSemiColonToggle
+```
+or better map it to the desireable key-bindings,`F9` for example:
+
+```vim
+nmap <F9> :AutoCommaOrSemiColonToggle<CR>
+```
+This will show a missage about the current state of the auto insetion mode (ON / OFF).  
+By default what triggers the auto insertion is leaving insert mode (`InsertLeave` event). This can be modified by changing the desired events in the events list:
+
+```vim
+let g:auto_comma_or_semicolon_events = ["InsertLeave"]
+```
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ let g:auto_comma_or_semicolon_events = ["InsertLeave"]
 ```
 __**Warning**__:
 
-> *This feature is currently experimental and still not mature enough to work for many vim events (e.g:* "TextChangedI"*)*
+> *This feature is currently experimental and still not mature enough to work for many vim events (e.g:* "TextChangedI"*) or in many places in your code, so use with care.*
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ autocmd FileType javascript,css,YOUR_LANG inoremap <silent> <Leader>; <c-o>:call
 
 and then you can just type `<Leader>;`.
 
-## Auto CommaOrSemicolon Insertion Mode
+## Auto CommaOrSemicolon Insertion Mode (Experimental)
 
 Auto insertion of a comma or a semicolon is also supported through the function:
 
@@ -80,6 +80,9 @@ By default what triggers the auto insertion is leaving insert mode (`InsertLeave
 ```vim
 let g:auto_comma_or_semicolon_events = ["InsertLeave"]
 ```
+__**Warning**__:
+
+> *This feature is currently experimental and still not mature enough to work for many vim events (e.g:* "TextChangedI"*)*
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ or better map it to the desireable key-bindings,`F9` for example:
 ```vim
 nmap <F9> :AutoCommaOrSemiColonToggle<CR>
 ```
-This will show a missage about the current state of the auto insetion mode (ON / OFF).  
+This will show a message about the current state of the auto insetion mode (ON / OFF).  
 By default what triggers the auto insertion is leaving insert mode (`InsertLeave` event). This can be modified by changing the desired events in the events list:
 
 ```vim

--- a/plugin/cosco.vim
+++ b/plugin/cosco.vim
@@ -1,0 +1,47 @@
+" File: plugin/cosco.vim
+"
+" To activate the AutoCommaOrSemiColon by default
+" add the following line to your vimrc:
+"   let g:auto_comma_or_semicolon = 1     " Default : 0
+"
+" For easy toggle you can map it:
+"   nmap <leader>; :AutoCommaOrSemiColonToggle<CR>
+"
+" By default what triggers the auto action is leaving Insert mode.
+" This can be changed by adding the desired events to the list:
+"   let g:auto_comma_or_semicolon_events = ["InsertLeave"]
+"
+
+if !exists("g:auto_comma_or_semicolon")
+    let g:auto_comma_or_semicolon = 0
+endif
+
+if !exists("g:auto_comma_or_semicolon_events")
+    let g:auto_comma_or_semicolon_events = ["InsertLeave"]
+endif
+
+augroup auto_comma_or_semicolon
+    autocmd!
+    for event in g:auto_comma_or_semicolon_events
+        execute "au " . event . " * call AutoCommaOrSemiColon()"
+    endfor
+augroup END
+
+command! AutoCommaOrSemiColonToggle :call AutoCommaOrSemiColonToggle()
+function! AutoCommaOrSemiColonToggle()
+    if g:auto_comma_or_semicolon >= 1
+        let g:auto_comma_or_semicolon = 0
+        echo "AutoCommaOrSemiColon is OFF"
+    else
+        let g:auto_comma_or_semicolon = 1
+        echo "AutoCommaOrSemiColon is ON"
+    endif
+endfunction
+
+command! CommaOrSemiColon call cosco#commaOrSemiColon()
+function! AutoCommaOrSemiColon()
+    let b:currentLineLastChar = matchstr(getline(line('.')), '.$')
+    if g:auto_comma_or_semicolon >= 1
+        call cosco#commaOrSemiColon()
+    endif
+endfunction

--- a/plugin/cosco.vim
+++ b/plugin/cosco.vim
@@ -28,7 +28,6 @@ endfunction
 
 command! CommaOrSemiColon call cosco#commaOrSemiColon()
 function! AutoCommaOrSemiColon()
-    let b:currentLineLastChar = matchstr(getline(line('.')), '.$')
     if g:auto_comma_or_semicolon >= 1
         call cosco#commaOrSemiColon()
     endif

--- a/plugin/cosco.vim
+++ b/plugin/cosco.vim
@@ -1,16 +1,4 @@
 " File: plugin/cosco.vim
-"
-" To activate the AutoCommaOrSemiColon by default
-" add the following line to your vimrc:
-"   let g:auto_comma_or_semicolon = 1     " Default : 0
-"
-" For easy toggle you can map it:
-"   nmap <leader>; :AutoCommaOrSemiColonToggle<CR>
-"
-" By default what triggers the auto action is leaving Insert mode.
-" This can be changed by adding the desired events to the list:
-"   let g:auto_comma_or_semicolon_events = ["InsertLeave"]
-"
 
 if !exists("g:auto_comma_or_semicolon")
     let g:auto_comma_or_semicolon = 0


### PR DESCRIPTION
This was suggested previously by @daGrevis in issue #4.
I find it useful for my own workflow, so here I share it.
It currently triggers inserting comma or semicolon when leaving insert mode on the same line only. It may a good start though.