### PR TITLE
Disable the auto add in all types of comments & explicitly ignore filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,33 @@ Or a merely indented comment:
 
 And the cursor is placed anywhere before the `//`, it won't work as vim won't identify the current cursor position's syntax to be a comment. Pull Requests are welcome to improve this.
 
+### Ignoring filetypes
+
+If you want to explicitly declare a set of filetypes that cosco will ignore you can add one of the following lines to your `.vimrc`:
+
+```vim
+let g:cosco_filetype_whitelist = ['php', 'javascript']
+let g:cosco_filetype_blacklist = ['vim', 'bash']
+```
+
+These variables must be declared as a list (array) of languages recognized by vim
+
+**Whitelist**  
+The `g:cosco_filetype_whitelist` variable is used to declare a list of filetypes that cosco will work in. If this variable is declared, cosco will ignore any filetype that is not specified in the whitelist variable.
+
+**Blacklist**  
+The `g:cosco_filetype_blacklist` variable is used to declare a list of filetypes that cosco will ignore. If this variable is declared, cosco will ignore any filetype that is specified in the blacklist variable.
+
+If neither of these variables are declared in the `.vimrc` cosco will work in any filetype. 
+
+The `g:cosco_filetype_whitelist` variable will override and ignore the `g:cosco_filetype_blacklist` variable if both variables are declared in your `.vimrc`.
+
+**Getting the current filetype**  
+You can easily get the current filetype by calling:
+```vim
+:set ft?
+```
+
 ## Auto CommaOrSemicolon Insertion Mode (Experimental)
 
 Auto insertion of a comma or a semicolon is also supported through the function:

--- a/autoload/cosco.vim
+++ b/autoload/cosco.vim
@@ -57,6 +57,26 @@ function! s:hasUnactionableLines()
     endif
 endfunction
 
+function! s:ignoreCurrentFiletype()
+    if(exists("g:cosco_filetype_whitelist"))
+        for i in g:cosco_filetype_whitelist
+            if (&ft == i)
+                return 0
+            endif
+        endfor
+        return 1
+    elseif(exists("g:cosco_filetype_blacklist"))
+        for i in g:cosco_filetype_blacklist
+            if(&ft == i)
+                return 1
+            endif
+        endfor
+        return 0
+    else
+        return 0
+    endif
+endfunction
+
 " =====================
 " Filetypes extensions:
 " =====================
@@ -104,6 +124,11 @@ endfunction
 function! cosco#commaOrSemiColon()
     " Don't run if we're in a readonly buffer:
     if (&readonly == 1)
+        return
+    endif
+
+    " Dont run if current filetype has been disabled:
+    if (s:ignoreCurrentFiletype())
         return
     endif
 

--- a/autoload/cosco.vim
+++ b/autoload/cosco.vim
@@ -40,7 +40,7 @@ endfunction
 function! s:hasUnactionableLines()
     " Ignores comment lines, if global option is configured
     if (g:cosco_ignore_comment_lines == 1)
-        let l:isComment = synIDattr(synID(line("."),col("."),1),"name") =~ 'omment$'
+        let l:isComment = synIDattr(synID(line("."),col("."),1),"name") =~ '\ccomment'
         if l:isComment
             return 1
         endif


### PR DESCRIPTION
Not all comment types were covered by the regex you added in your comment option commit. Many syntax groups for comments do not end with 'comment' and instead have a syntax group name like "jsCommentExtra" but is still classified as a comment. 

This updated regex searches simply for the word "Comment" in the syntax group name, ignoring case.

This should fully address issue #13 