### PR TITLE
Check for substring matches on whitelist and blacklist filetypes

### DIFF
--- a/autoload/cosco.vim
+++ b/autoload/cosco.vim
@@ -64,9 +64,10 @@ function! s:hasUnactionableLines()
 endfunction
 
 function! s:ignoreCurrentFiletype()
+    let filetypes = split(&ft, '\.')
     if (exists("g:cosco_filetype_whitelist"))
         for i in g:cosco_filetype_whitelist
-            if (&ft == i)
+            if (index(filetypes, i) > -1)
                 return 0
             endif
         endfor
@@ -74,7 +75,7 @@ function! s:ignoreCurrentFiletype()
         return 1
     elseif (exists("g:cosco_filetype_blacklist"))
         for i in g:cosco_filetype_blacklist
-            if (&ft == i)
+            if (index(filetypes, i) > -1)
                 return 1
             endif
         endfor


### PR DESCRIPTION
Whitelist and blacklist don't work for filetypes like "javascript.jsx" (or any filetype with multiple types).