### PR TITLE
Ignore regex per ft

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ You can easily get the current filetype by calling:
 :set ft?
 ```
 
+**Custom regex ignore patterns per filetype**
+For more granular control, if you need to ignore a regex pattern per filetype you can use this dictionary `g:cosco_ignore_ft_pattern`, for example:
+
+```
+let g:cosco_ignore_ft_pattern = {
+      \ 'cpp': '^#',
+      \ 'c': '^#',
+      \ 'd': '^.*cornerCase',
+      \}
+
+```
+
 ## Auto CommaOrSemicolon Insertion Mode (Experimental)
 
 Auto insertion of a comma or a semicolon is also supported through the function:

--- a/autoload/cosco.vim
+++ b/autoload/cosco.vim
@@ -3,6 +3,7 @@
 " ==============
 
 let g:cosco_ignore_comment_lines = get(g:, 'cosco_ignore_comment_lines', 0)
+let g:cosco_ignore_ft_pattern = get(g:, 'cosco_ignore_ft_pattern', {})
 
 " =================
 " Helper functions:
@@ -60,6 +61,14 @@ function! s:hasUnactionableLines()
     " Ignores lines if the next one starts with a "{"
     if b:nextLineFirstChar == '{'
         return 1
+    endif
+
+    " Ignores custom regex patterns given a file type.
+    let s:cur_ft = &filetype
+    if has_key(g:cosco_ignore_ft_pattern, s:cur_ft)
+      if match(getline(line(".")), g:cosco_ignore_ft_pattern[s:cur_ft]) != -1
+        return 1
+      endif
     endif
 endfunction
 

--- a/examples/area.cpp
+++ b/examples/area.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+/* the line above was ignored because of this setting
+let g:cosco_ignore_ft_pattern = {
+      \ 'cpp': '^#',
+}
+*/
+
+float triangle_area(float a, float b) { return a * b / 2.0; };
+
+int main(int argc, char *argv[]) {
+  auto area = triangle_area(10, 20);
+  std::cout << "area " << area << std::endl;
+  return 0;
+}

--- a/examples/fib.d
+++ b/examples/fib.d
@@ -1,0 +1,24 @@
+import std.stdio;
+
+int fib(int n) @safe pure nothrow {
+    if (n == 0) {
+        return 0;
+    }
+    if (n == 1) {
+        return 1;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+void main() {
+    foreach (elem; 0 .. 15) {
+        writeln(fib(elem));
+    }
+    auto someRandomVar = 10;
+    auto ignoreThisVariable
+    /* the line above has a syntax error, because the line was ignored by this setting:
+    let g:cosco_ignore_ft_pattern = {
+          \ 'd': '^.*ignoreThisVariable',
+    }
+    */
+}


### PR DESCRIPTION
Hi @lfilho, 

Here's the PR for the issue #21. I also added two examples that you suggested. Initially, I wasn't planning to add this new `g:cosco_ignore_ft_pattern` setting on the README.md, but since there was no plain text doc, I figured that might be helpful for other users too. 

Based on my tests, it's working as expected per filetype:

```
let g:cosco_ignore_ft_pattern = {
      \ 'cpp': '^#',
      \ 'd': '^.*ignoreThisVariable',
      \}
```

Cheers!